### PR TITLE
fixing bower component path

### DIFF
--- a/generated/server/app.js
+++ b/generated/server/app.js
@@ -14,7 +14,7 @@ var nodePath = path.join(__dirname, '../node_modules');
 Meaniscule doesn't use Bower by default. To use Bower,
 uncomment the following line and the related `app.use` line below.
 */
-// var bowerPath = path.join(__dirname, '../../bower_components');
+// var bowerPath = path.join(__dirname, '../bower_components');
 
 app.use(logger('dev'));
 app.use(bodyParser.json());

--- a/generated/server/app.nodb.js
+++ b/generated/server/app.nodb.js
@@ -13,7 +13,7 @@ var nodePath = path.join(__dirname, '../node_modules');
 Meaniscule doesn't use Bower by default. To use Bower,
 uncomment the following line and the related `app.use` line below.
 */
-// var bowerPath = path.join(__dirname, '../../bower_components');
+// var bowerPath = path.join(__dirname, '../bower_components');
 
 app.use(logger('dev'));
 app.use(bodyParser.json());


### PR DESCRIPTION
Before, it was looking for the bower components directory in the same folder that the root directory was in rather than in the root directory
