### PR TITLE
Issue 76: move meta tag into head

### DIFF
--- a/generated/server/index.html
+++ b/generated/server/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <base href="/" />
     <title>Meaniscule</title>
 


### PR DESCRIPTION
Meta tag was incorrectly placed above `body`. This adds it to `head` instead.
