### PR TITLE
Issue 69: Clean up modules.controller logic

### DIFF
--- a/generated/client/pre-build/modules/modules.controller.js
+++ b/generated/client/pre-build/modules/modules.controller.js
@@ -1,13 +1,13 @@
-app.controller('ModulesController', function($scope, $http, ModulesFactory) {
-  
+app.controller('ModulesController', function($scope, ModulesFactory) {
+
   $scope.$on('$stateChangeSuccess', function () {
     var defaultMessage = 'If you don\'t see a list of links here, you need to seed your database!\nIn your terminal, go to this app\'s directory and run `gulp seedDB`.\nThen try this page again.';
 
     ModulesFactory.getNodeModules()
       .then(function(modules) {
-        $scope.nodeModules = modules;
-        
-        if (!$scope.nodeModules.length) {
+        if (modules.length) {
+          $scope.nodeModules = modules;
+        } else {
           $scope.defaultMessage = defaultMessage;
         }
       });


### PR DESCRIPTION
Previous logic in `ModulesController` assigned returned modules to `$scope.nodemodules` even if no modules were returned. This tests for if modules is not empty first.

Also removed unused inject `$http`.
