### PR TITLE
don't rely on global gulp

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -34,20 +34,20 @@ var renameNoDbFiles = function renameNoDbFiles() {
 var removeDbFiles = function removeDbFiles() {
   return new Promise(function(resolve, reject) {
     exec('rm -r ./client/pre-build/modules/ ./seed.js ./server/api/ ./server/db.js', function(error, stdout, stderr) {
-      if(error) return reject(stderr); 
+      if(error) return reject(stderr);
       else return resolve(stdout);
-    }); 
+    });
   });
 };
 
 var removeNoDbFiles = function removeNoDbFiles() {
   return new Promise(function(resolve, reject) {
     exec('find . -type f -name "*.nodb*" -delete', function(error, stdout, stderr) {
-      if(error) return reject(stderr); 
+      if(error) return reject(stderr);
       else return resolve(stdout);
-    }); 
+    });
   });
-  
+
 };
 
 var copyFiles = function () {
@@ -80,10 +80,9 @@ copyFiles()
     console.log(chalk.yellow('Run the following commands to get set up:'));
     console.log(chalk.white.bgBlack('- [Terminal 1] npm install '));
     console.log(chalk.white.bgBlack('- [Terminal 1] npm start   '));
-    if(!noDb) console.log(chalk.white.bgBlack('- [Terminal 2] gulp seedDB '));
-    console.log(chalk.white.bgBlack('- [Terminal 2] gulp        '));
+    if(!noDb) console.log(chalk.white.bgBlack('- [Terminal 2] npm run seed '));
+    console.log(chalk.white.bgBlack('- [Terminal 2] npm run build       '));
 })
 .catch(function(err) {
     console.log(err);
 });
-

--- a/generated/gulpfile.js
+++ b/generated/gulpfile.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp');
-var run = require('gulp-run');
 var plumber = require('gulp-plumber');
 var sourcemaps = require('gulp-sourcemaps');
 var concat = require('gulp-concat');
@@ -33,12 +32,6 @@ gulp.task('default', function() {
 
     gulp.watch(['server/**/*.js'], ['testServerJS']);
 
-});
-
-
-// Database seed
-gulp.task('seedDB', function() {
-    run('node seed.js').exec();
 });
 
 

--- a/generated/package.json
+++ b/generated/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Tests should be run from `gulp`. Please see `gulpfile.js` for available testing tasks.\" && exit 1",
     "start": "nodemon --watch server server/start.js",
-    "postinstall": "gulp build"
+    "postinstall": "gulp build",
+    "seed": "node ./seed.js",
+    "watch": "gulp"
   },
   "dependencies": {
     "angular": "^1.4.1",
@@ -22,7 +24,6 @@
     "gulp-concat": "^2.5.2",
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-run": "^1.6.8",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "jquery": "^2.1.4",


### PR DESCRIPTION
This PR utilizes npm scripts to use the local gulp to run the tasks needing for building and watching the javascript/css bundles as well as seeding the database.
- To watch the bundle, the user will only have to use the `npm run watch` command.  This will run the default gulp task.
- To seed the database, the user will run the `npm run seed` command which just calls seed.js with the node cli.  This makes `gulp-run` unnecessary.
