### PR TITLE
use local gulp and npm scripts

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -119,8 +119,8 @@ copyFiles()
         console.log(chalk.yellow('Run the following commands to get set up:'));
         console.log(chalk.white.bgBlack('- [' + codeyBits + ' 1] npm install '));
         console.log(chalk.white.bgBlack('- [' + codeyBits + ' 1] npm start   '));
-        if (!noDb) console.log(chalk.white.bgBlack('- [' + codeyBits + ' 2] gulp seedDB '));
-        console.log(chalk.white.bgBlack('- [' + codeyBits + ' 2] gulp'));
+        if (!noDb) console.log(chalk.white.bgBlack('- [' + codeyBits + ' 2] npm run seed '));
+        console.log(chalk.white.bgBlack('- [' + codeyBits + ' 2] npm run watch'));
     })
     .catch(function(err) {
         console.log(err);

--- a/generated/gulpfile.js
+++ b/generated/gulpfile.js
@@ -8,8 +8,6 @@ const livereload = require('gulp-livereload');
 const rename = require('gulp-rename');
 const mocha = require('gulp-mocha');
 const babel = require('gulp-babel');
-const exec = require('child_process').exec;
-const chalk = require('chalk');
 
 // Live reload
 gulp.task('reload', function() {
@@ -33,22 +31,6 @@ gulp.task('default', function() {
     gulp.watch(['client/**/*.html', 'server/*.html'], ['reload']);
 
     gulp.watch(['server/**/*.js'], ['testServerJS']);
-
-});
-
-
-// Database seed
-gulp.task('seedDB', function(cb) {
-
-    exec('node seed.js', (err, stdout, stderr) => {
-        if (err) {
-            console.error(chalk.red(err));
-            process.exit(err.code);
-        }
-        console.log(chalk.green(stdout));
-        console.log(chalk.red(stderr));
-        process.exit(0);
-    });
 
 });
 

--- a/generated/package.json
+++ b/generated/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Tests should be run from `gulp`. Please see `gulpfile.js` for available testing tasks.\" && exit 1",
     "start": "nodemon --watch server server/start.js",
-    "postinstall": "gulp build"
+    "postinstall": "gulp build",
+    "seed": "node ./seed.js",
+    "watch": "gulp"
   },
   "dependencies": {
     "angular": "^1.4.1",

--- a/generated/package.nodb.json
+++ b/generated/package.nodb.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Tests should be run from `gulp`. Please see `gulpfile.js` for available testing tasks.\" && exit 1",
     "start": "nodemon --watch server server/start.js",
-    "postinstall": "gulp build"
+    "postinstall": "gulp build",
+    "seed": "node ./seed.js",
+    "watch": "gulp"
   },
   "dependencies": {
     "angular": "^1.4.1",

--- a/generated/seed.js
+++ b/generated/seed.js
@@ -17,7 +17,7 @@ var moduleNamesArray;
 
 startDb.then(function() {
   // Get all module names
-  fs.readdirAsync(__dirname + '/node_modules/')
+  return fs.readdirAsync(__dirname + '/node_modules/')
     // Get package.json content for all modules
     .then(function(moduleNames) {
       moduleNamesArray = moduleNames.filter(function(e) {
@@ -64,7 +64,11 @@ startDb.then(function() {
       console.log(chalk.green('Database seeded. Goodbye!'));
       process.exit(0);
     });
-});
+})
+.catch(function(err){
+  console.error(chalk.red(err));
+  process.exit(err.code);
+})
 
 function urlCleaner(url) {
  var start;


### PR DESCRIPTION
This PR uses local gulp instead of having the user rely on installing the `gulp-cli`globally on their machine.  By using npm scripts to watch the build via `npm run watch`, npm will look for the local gulp that is installed.

This PR also gets rid of the gulp task that is doing an unnecessary `exec` call to seed the database.  By using npm scripts the user can just run `npm run seed` in the command line and it will seed the database without using gulp.
